### PR TITLE
feat: introduce `clickId` for click handling and remove `clickable`

### DIFF
--- a/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/DynamicLayout.kt
+++ b/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/DynamicLayout.kt
@@ -85,7 +85,7 @@ private fun ChildDynamicLayout(
     modifier: Modifier = Modifier,
     path: String = "root",
     parentScrollable: Boolean = false,
-    onClickHandler: (String) -> Unit = {},
+    onClickHandler: (String) -> Unit,
 ) {
     val componentToRender =
         component
@@ -102,7 +102,7 @@ private fun ChildDynamicLayout(
         }
     }
 
-    val currentModifier = applyJsonModifier(modifier, componentToRender.scopedModifier)
+    val currentModifier = applyJsonModifier(modifier, componentToRender.scopedModifier, onClickHandler)
 
     when (componentToRender) {
         is LayoutComponent.Column ->

--- a/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/Models.kt
+++ b/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/Models.kt
@@ -172,7 +172,7 @@ data class BaseModifier(
     val border: BorderValues? = null,
     val shadow: ShadowValues? = null,
     val scrollable: Boolean? = false,
-    val clickable: Boolean? = false,
+    val clickId: String? = null,
     val alpha: Float? = null,
     val rotate: Float? = null,
     val scale: ScaleValues? = null,

--- a/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/Modifiers.kt
+++ b/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/Modifiers.kt
@@ -31,10 +31,11 @@ import androidx.compose.ui.unit.dp
 fun applyJsonModifier(
     base: Modifier = Modifier,
     scopedModifier: ScopedModifier?,
+    onClickHandler: (String) -> Unit,
 ): Modifier {
     if (scopedModifier == null) return base
 
-    var mod = applyBaseModifier(base, scopedModifier.base)
+    var mod = applyBaseModifier(base, scopedModifier.base, onClickHandler)
 
     mod =
         when (scopedModifier) {
@@ -50,6 +51,7 @@ fun applyJsonModifier(
 private fun applyBaseModifier(
     mod: Modifier,
     base: BaseModifier,
+    onClickHandler: (String) -> Unit,
 ): Modifier {
     val modifierOrder = ModifierOrderTracker.getCurrentOrder()
     val modifierMap = mutableMapOf<String, Modifier>()
@@ -177,8 +179,10 @@ private fun applyBaseModifier(
             }
     }
 
-    if (base.clickable == true) {
-        modifierMap["clickable"] = Modifier.clickable { }
+    if (base.clickId != null) {
+        modifierMap["clickId"] = Modifier.clickable {
+            onClickHandler(base.clickId)
+        }
     }
     if (base.scrollable == true) {
         modifierMap["scrollable"] = Modifier

--- a/jsonBuilderWeb/src/jsMain/resources/schema.json
+++ b/jsonBuilderWeb/src/jsMain/resources/schema.json
@@ -110,6 +110,9 @@
           },
           "fillMaxHeight": {
             "type": "boolean"
+          },
+          "clickId": {
+            "type": "string"
           }
         }
       },


### PR DESCRIPTION
This commit replaces the boolean `clickable` property with a `clickId` string in the layout component's base modifier. This change enables more flexible click handling by allowing identification of which component was clicked.  The `applyJsonModifier` function is updated to handle `clickId` instead of `clickable`, triggering the provided `onClickHandler` with the `clickId` when a click occurs. Also update schema.json to include clickId property.