### PR TITLE
Feature: Add saved scroll position

### DIFF
--- a/compose-remote-layout/build.gradle.kts
+++ b/compose-remote-layout/build.gradle.kts
@@ -46,6 +46,8 @@ kotlin {
             implementation(libs.kotlinx.coroutines.core)
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.kotlinx.serialization.json)
+
+            implementation(libs.kotlinx.datetime)
         }
 
         commonTest.dependencies {

--- a/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/CacheScrollPosition.kt
+++ b/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/CacheScrollPosition.kt
@@ -1,0 +1,30 @@
+package com.utsman.composeremote
+
+import androidx.compose.runtime.compositionLocalOf
+
+class CacheScrollPosition {
+    private val map = mutableMapOf<String, Int>()
+
+    fun put(
+        key: String,
+        value: Int,
+    ): Int? = map.put(key, value)
+
+    fun get(
+        key: String?,
+    ): Int = map[key] ?: 0
+
+    val size get() = map.size
+
+    fun remove(key: String): Int? = map.remove(key)
+
+    fun clear() = map.clear()
+
+    operator fun plus(other: CacheScrollPosition): CacheScrollPosition {
+        val otherMap = other.map
+        map.putAll(otherMap)
+        return this
+    }
+}
+
+val LocalCacheScrollPosition = compositionLocalOf { CacheScrollPosition() }

--- a/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/ScrollStateStopDetector.kt
+++ b/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/ScrollStateStopDetector.kt
@@ -1,0 +1,77 @@
+@file:Suppress("ktlint:standard:filename")
+
+package com.utsman.composeremote
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import kotlinx.coroutines.delay
+import kotlinx.datetime.Clock
+
+@Composable
+fun rememberScrollStopDetector(
+    scrollState: ScrollState,
+    debounceTime: Long = 100,
+    onScrollStart: (() -> Unit)? = null,
+    onScrollStopped: ((position: Int) -> Unit)? = null,
+): ScrollStopDetectorState {
+    var isScrolling by remember { mutableStateOf(false) }
+    var scrollStoppedAt by remember { mutableStateOf(0) }
+    var lastScrollChangeTime by remember { mutableStateOf(0L) }
+
+    LaunchedEffect(scrollState) {
+        var previousScrolling = false
+
+        while (true) {
+            val currentlyScrolling =
+                scrollState.isScrollInProgress
+            val currentPosition = scrollState.value
+            val currentTime =
+                Clock.System.now().toEpochMilliseconds()
+
+            if (currentlyScrolling && !previousScrolling) {
+                isScrolling = true
+                lastScrollChangeTime = currentTime
+                onScrollStart?.invoke()
+            }
+
+            if (scrollStoppedAt != currentPosition) {
+                scrollStoppedAt = currentPosition
+                lastScrollChangeTime = currentTime
+            }
+
+            if (!currentlyScrolling &&
+                isScrolling &&
+                (currentTime - lastScrollChangeTime > debounceTime)
+            ) {
+                isScrolling = false
+                onScrollStopped?.invoke(currentPosition)
+            }
+
+            previousScrolling = currentlyScrolling
+            delay(16)
+        }
+    }
+
+    return remember(
+        isScrolling,
+        scrollState.value,
+        scrollStoppedAt,
+    ) {
+        ScrollStopDetectorState(
+            isScrolling = isScrolling,
+            currentPosition = scrollState.value,
+            stoppedPosition = scrollStoppedAt,
+        )
+    }
+}
+
+data class ScrollStopDetectorState(
+    val isScrolling: Boolean,
+    val currentPosition: Int,
+    val stoppedPosition: Int,
+)


### PR DESCRIPTION
* feat: add scroll position caching and stop detection
  - This commit introduces scroll position caching and stop detection features to the compose remote layout library.
  - Adds `CacheScrollPosition` to save and restore the scroll position of scrollable layouts.
  - Adds `ScrollStateStopDetector` to detect when scrolling has stopped in a `ScrollState`.
  - Adds `rememberScrollStopDetector` composable function to manage scroll state, debounce time, and events.
  - `DynamicLayout`, `ColumnLayout`, `RowLayout`, `GridLayout` components now utilize the new scroll caching and detector.
  - Updates `build.gradle.kts` to include the `kotlinx-datetime` library.
  - Improves performance by caching scroll position.
  - Adds ability to listen on scroll start and stop events.
  - Updates `BindsValue` to be rememberable.
