### PR TITLE
Feature: Router root handling

### DIFF
--- a/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/DynamicLayout.kt
+++ b/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/DynamicLayout.kt
@@ -393,10 +393,6 @@ private fun RenderGrid(
 
     val orientation = scopedMod?.orientation
 
-    println("cuasks parent orientation ----> current: $orientation | parent: $parentOrientation")
-    println("cuasks parent scrollable ----> $parentScrollable")
-    println("cuasks scrollable ----> ${scopedMod?.base?.scrollable}")
-
     val isScrollable =
         scopedMod?.base?.scrollable == true && (!parentScrollable || (parentOrientation != orientation))
 
@@ -467,7 +463,6 @@ private fun RenderGrid(
         } ?: Arrangement.SpaceAround
 
     if (orientation == "horizontal") {
-        println("cuasks scrollable ----> $isScrollable | height -> ${scopedMod.base.height}")
         val gridModifier =
             if (isScrollable) {
                 if (scopedMod.base.height != null) {

--- a/samples/routerApp/composeApp/src/commonMain/kotlin/router/app/App.kt
+++ b/samples/routerApp/composeApp/src/commonMain/kotlin/router/app/App.kt
@@ -2,11 +2,12 @@ package router.app
 
 import androidx.compose.material.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import com.utsman.composeremote.router.ComposeRemoteRouter
 import com.utsman.composeremote.router.KtorHttpLayoutFetcher
-import com.utsman.composeremote.router.NavigationEventContainer
 import com.utsman.composeremote.router.ResultRouterFactory
 import com.utsman.composeremote.router.cached
 
@@ -23,18 +24,16 @@ fun App() {
             )
         }
 
-        val navigationEventContainer =
-            remember { NavigationEventContainer() }
+        val isRoot by router.isRoot.collectAsState()
 
-        BackPress {
-            navigationEventContainer.pop()
+        BackPress(!isRoot) {
+            router.popUrl()
         }
 
         ComposeRemoteRouter(
             baseUrl = "https://crl-marketplace.codeutsman.com",
             initialPath = "home",
             router = router,
-            navigationEventContainer = navigationEventContainer,
         )
     }
 }


### PR DESCRIPTION
* refactor: optimize grid layout and scrollable behavior in DynamicLayout
  - Removed unnecessary print statements related to `parentOrientation`, `parentScrollable`, and `scrollable`.
  - Improved the conditional logic for determining scrollable state, now considering parent's scrollable and orientation.
  - Optimized how grid modifiers are applied based on scrollable and height properties.

* feat: add `isRoot` state to `RemoteRouter` and implement stack size check
  - Adds `isRoot` as a `StateFlow<Boolean>` in `RemoteRouter` to indicate if the current screen is the root screen.
  - Implements `calculateIsRoot()` to check and update `isRoot` state based on `urlStack` size.
  - Updates logic in `pushUrl`, `popUrl`, `clearHistory` and inside of collect of fetchLayoutAsFlow to correctly update `isRoot` when the stack size changes.

* feat: add `popUrl` and `isRoot` to `ComposeRemoteRouter` for improved navigation handling
  - This commit introduces new features to `ComposeRemoteRouter` for better navigation management:
  - Adds `popUrl` method to allow navigating back.
  - Adds `isRoot` observable state to track if the current view is root.
  - Updates `BackPress` to pop url based on `isRoot` state.

