### PR TITLE
feat: enhance horizontal grid with snap and caching features

### DIFF
--- a/compose-remote-layout-router/src/commonMain/kotlin/com/utsman/composeremote/router/RemoteRouter.kt
+++ b/compose-remote-layout-router/src/commonMain/kotlin/com/utsman/composeremote/router/RemoteRouter.kt
@@ -29,7 +29,7 @@ interface RemoteRouter {
     fun reload()
 }
 
-class ResultRemoteRouterImpl(
+internal class ResultRemoteRouterImpl(
     private val fetcher: LayoutFetcher,
     private val scope: CoroutineScope,
 ) : RemoteRouter {

--- a/compose-remote-layout-router/src/commonMain/kotlin/com/utsman/composeremote/router/ResultLayout.kt
+++ b/compose-remote-layout-router/src/commonMain/kotlin/com/utsman/composeremote/router/ResultLayout.kt
@@ -65,6 +65,7 @@ sealed class ResultLayout<out T> {
             try {
                 emit(Success(block()))
             } catch (e: Exception) {
+                e.printStackTrace()
                 emit(Failure(e))
             }
         }

--- a/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/CacheScrollPosition.kt
+++ b/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/CacheScrollPosition.kt
@@ -19,12 +19,26 @@ class CacheScrollPosition {
     fun remove(key: String): Int? = map.remove(key)
 
     fun clear() = map.clear()
+}
 
-    operator fun plus(other: CacheScrollPosition): CacheScrollPosition {
-        val otherMap = other.map
-        map.putAll(otherMap)
-        return this
-    }
+class CacheScrollOffsetPosition {
+    private val map = mutableMapOf<String, Pair<Int, Int>>()
+
+    fun put(
+        key: String,
+        value: Pair<Int, Int>,
+    ): Pair<Int, Int>? = map.put(key, value)
+
+    fun get(
+        key: String?,
+    ): Pair<Int, Int> = map[key] ?: Pair(0, 0)
+
+    val size get() = map.size
+
+    fun remove(key: String): Pair<Int, Int>? = map.remove(key)
+
+    fun clear() = map.clear()
 }
 
 val LocalCacheScrollPosition = compositionLocalOf { CacheScrollPosition() }
+val LocalCacheScrollOffsetPosition = compositionLocalOf { CacheScrollOffsetPosition() }

--- a/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/Models.kt
+++ b/compose-remote-layout/src/commonMain/kotlin/com/utsman/composeremote/Models.kt
@@ -159,6 +159,7 @@ sealed class ScopedModifier {
         val columns: Int? = null,
         val rows: Int? = null,
         val orientation: String? = null,
+        val enableSnapHorizontal: Boolean? = false,
         val horizontalArrangement: String? = null,
         val verticalArrangement: String? = null,
     ) : ScopedModifier()
@@ -179,6 +180,7 @@ data class LayoutModifier(
     val columns: Int? = null,
     val rows: Int? = null,
     val orientation: String? = null,
+    val enableSnapHorizontal: Boolean? = false,
 ) {
     fun toScopedModifier(type: String): ScopedModifier = when (type) {
         "column" -> ScopedModifier.Column(
@@ -203,6 +205,7 @@ data class LayoutModifier(
             columns = columns ?: 1,
             rows = rows ?: 1,
             orientation = orientation ?: "vertical",
+            enableSnapHorizontal = enableSnapHorizontal,
             horizontalArrangement = horizontalArrangement,
             verticalArrangement = verticalArrangement,
         )


### PR DESCRIPTION
- Adds `enableSnapHorizontal` option to `ScopedModifier.Grid` for enabling snapping in horizontal grids.
- Implements `ScrollableHorizontalGrid` for snap behavior and horizontal scrolling.
- Introduces `CacheScrollOffsetPosition` to cache scroll position with offset.
- Updates `rememberLazyScrollStopDetector` to handle lazy list states and scroll stops.
- Updates `KtorHttpLayoutFetcher` to validate JSON content and add a default client.
- Improves `CachedKtorLayoutFetcher` for better cache management.
- Updates `ResultLayout` to print the stacktrace in case of failure.