### PR TITLE
feat: Update Docker setup to use Node.js and simplify configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,10 @@
-FROM eclipse-temurin:17-jdk
+FROM node:18-alpine
 
-RUN apt-get update && apt-get install -y curl unzip
+RUN npm install -g live-server
 
 WORKDIR /app
 
-COPY . .
-
-RUN chmod +x ./gradlew
+COPY ./wasmJsDist ./wasmJsDist
 
 EXPOSE 8080
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,12 +5,3 @@ services:
       dockerfile: Dockerfile
     ports:
       - "8083:8080"
-    environment:
-      - GRADLE_OPTS="-Dorg.gradle.daemon=true -Dorg.gradle.parallel=true -Dkotlin.incremental=true"
-    restart: unless-stopped
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 60s


### PR DESCRIPTION
- Changes the base Docker image from `eclipse-temurin:17-jdk` to `node:18-alpine`.
- Installs `live-server` globally using npm.
- Copies only the `./wasmJsDist` directory to the container instead of all files.
- Removes unnecessary `environment`, `healthcheck` and `restart` configurations from `docker-compose.yaml`.
- Removes the RUN chmod +x ./gradlew from Dockerfile
- Removes unnecessary run commands in Dockerfile