### PR TITLE
Feature: Router refine

### DIFF
--- a/compose-remote-layout-router/src/commonMain/kotlin/com/utsman/composeremote/router/RenderEvent.kt
+++ b/compose-remote-layout-router/src/commonMain/kotlin/com/utsman/composeremote/router/RenderEvent.kt
@@ -1,0 +1,20 @@
+package com.utsman.composeremote.router
+
+import com.utsman.composeremote.BindsValue
+import com.utsman.composeremote.LayoutComponent
+
+sealed class RenderEvent {
+    data class RenderedLayout(
+        val component: LayoutComponent,
+        val path: String,
+        val bindsValue: BindsValue,
+        val clickEvent: (String) -> Unit,
+    ) : RenderEvent()
+
+    data class Loading(val path: String) : RenderEvent()
+
+    data class Failure(
+        val error: Throwable,
+        val path: String,
+    ) : RenderEvent()
+}


### PR DESCRIPTION
* feat(router): Add RenderEvent for managing different states of remote layout rendering
  - Introduces `RenderEvent` to handle loading, success, and failure states of layout rendering.
  - Updates `ComposeRemoteRouter` to utilize `RenderEvent` via the `onRenderEvent` parameter.
  - Implements `RenderedLayout`, `Loading`, and `Failure` events within `RenderEvent` to provide more structured information about the rendering process.
  - Enhances the management of remote layout rendering by removing the old error and loading composable.

* feat(router): Implement conditional content rendering for ComposeRemoteRouter
  - Adds conditional rendering to `ComposeRemoteRouter` based on `RenderEvent`.
  - Implements loading, failure, and rendered layout states.
  - Displays loading text and a `CircularProgressIndicator` during loading.
  - Shows error message on failure.
  - Renders `DynamicLayout` for successful layout rendering.
  - Uses `Scaffold` to wrap the conditional content.
  - Improves `KtorHttpLayoutFetcher` usage.
  - Improves `cached()` usage.
