### PR TITLE
refactor(github): Disable recursive submodule checkout in sample-router-deploy workflow

### DIFF
--- a/.github/workflows/sample-router-deploy.yaml
+++ b/.github/workflows/sample-router-deploy.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          submodules: 'recursive'
+          submodules: false
 
       - name: Set up JDK
         uses: actions/setup-java@v3


### PR DESCRIPTION
- Updates the sample-router-deploy.yaml workflow to set `submodules` to `false` during the checkout step.